### PR TITLE
Wisej.Web.Ext.ColumnFilter Security Fix Nuget

### DIFF
--- a/Wisej.Web.Ext.ColumnFilter/Wisej.Web.Ext.ColumnFilter.csproj
+++ b/Wisej.Web.Ext.ColumnFilter/Wisej.Web.Ext.ColumnFilter.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.15" />
+	<PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.7" />
 	<PackageReference Include="Wisej-3" Version="3.5.*-*" />
 	<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
- Update System.Linq.Dynamic.Core Version 1.2.15 => 1.3.7
- Fixes https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMLINQDYNAMICCORE-5734234
- Get rid of nuget security warnings in Visual Studio